### PR TITLE
HAWKULAR-105 Swagger: parameter "Notes" text is not correct

### DIFF
--- a/asciidoc.mustache
+++ b/asciidoc.mustache
@@ -83,9 +83,9 @@ NOTE: *{{summary}}* {{#notes}}+
 === {{name}}
 [options="header"]
 |=======================
-| name | type | required | access | description | notes
+| Name | Type | Required | Description | Allowable Values
 {{#items}}
-|{{name}}|{{#linkType}}{{linkType}}{{type}} {{/linkType}}{{^linkType}}{{type}}{{/linkType}}|{{#required}}required{{/required}}{{^required}}optional{{/required}}|{{#access}}{{{access}}}{{/access}}{{^access}}-{{/access}}|{{#description}}{{{description}}}{{/description}}{{^description}}-{{/description}}{{#allowableValue}} Allowable values:{{.}}{{/allowableValue}}|{{#notes}}{{{notes}}}{{/notes}}{{^notes}}-{{/notes}}
+|{{name}}|{{type}}|{{#required}}required{{/required}}{{^required}}optional{{/required}}|{{#description}}{{{description}}}{{/description}}{{^description}}-{{/description}}|{{#allowableValue}}{{{allowableValue}}}{{/allowableValue}}{{^allowableValue}}-{{/allowableValue}}
 {{/items}}
 |=======================
 


### PR DESCRIPTION
Notes attribute isn't available in Swagger ApiModel schema. So the to Swagger Maven plugin simply copies the description field.

Removed the notes column and replaced it with allowable values.
Changed column names to uppercase.
Removed the access column.
Simplified the type column (give the name only instead of trying to
build a link).
