### PR TITLE
HAWKULAR-120 Blog: author not displayed in archive view and RSS feed

### DIFF
--- a/src/main/jbake/templates/archive.ftl
+++ b/src/main/jbake/templates/archive.ftl
@@ -16,7 +16,7 @@
     <#list partitions?first as post>
     	<#if (post.status == "published")>
             <a href="${post.uri}"><h1><#escape x as x?xml>${post.title}</#escape></h1></a>
-            <p>${post.date?string("dd MMMM yyyy")}</p>
+            <p>${post.date?string("dd MMMM yyyy")}<#if post.author??>, by ${post.author}</#if></p>
             <p>${post.body}</p>
             <br />
             <hr /><br />

--- a/src/main/jbake/templates/feed.ftl
+++ b/src/main/jbake/templates/feed.ftl
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8" ?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Hawkular Blog</title>
@@ -13,6 +13,9 @@
     <item>
       <title><#escape x as x?xml>${post.title}</#escape></title>
       <link>${config.site_host}/${post.uri}</link>
+      <#if post.author??>
+      <author>noreply@hawkular.org (${post.author})</author>
+      </#if>
       <pubDate>${post.date?string("EEE, d MMM yyyy HH:mm:ss Z")}</pubDate>
       <guid isPermaLink="false">${post.uri}</guid>
       	<description>
@@ -23,5 +26,5 @@
     </item>
     </#list>
 
-  </channel> 
+  </channel>
 </rss>


### PR DESCRIPTION
HAWKULAR-120 Blog: author not displayed in archive view and RSS feed

Not that the RSS author field follows the RSS standard (email + name)
