### PR TITLE
Adapt to HAWKULAR-384 changes

### DIFF
--- a/src/main/jbake/content/docs/dev/development.adoc
+++ b/src/main/jbake/content/docs/dev/development.adoc
@@ -76,7 +76,7 @@ cd hawkular
 mvn install
 cd dist/target
 unzip hawkular-x.y.x.zip
-cd wildfly-8.2.0.Final
+cd hawkular-x.y.z
 bin/standalone.sh
 ----
 

--- a/src/main/jbake/content/docs/dev/ui-dev.adoc
+++ b/src/main/jbake/content/docs/dev/ui-dev.adoc
@@ -59,7 +59,7 @@ prototype quickly, seeing their changes instantly when they save since the brows
  For agile development, we're using the watch feature of the gulp tool. Gulp can watch for changes in source files
  and update the compiled console accordingly.
  The advantage of this approach is, that is scans for file changes in the source directory and apply them directly
- into the target directory (`$HAWKULAR_ROOT/dist/target/hawkular-x.y.x-SNAPSHOT/wildfly-x.y.z.Final/`), which is suitable for console
+ into the target directory (`$HAWKULAR_ROOT/dist/target/hawkular-x.y.z-SNAPSHOT/hawkular-x.y.z-SNAPSHOT/`), which is suitable for console
  developing since it doesn't require the whole maven build to see the actual changes in the console UI.
 
 Assuming that https://nodejs.org/[node.js] is already installed (can also be installed via rpm or homebrew on mac):
@@ -70,7 +70,7 @@ You can re-build the console using java-script based Gulp tools. There are only 
 
 . This is done after the maven build and with a running Hawkular server
 .. *Build* Hawkular: `mvn clean install -Pdev,link`
-.. *Run* Hawkular: `cd dist/target/cd ui/console/target/gulp-build/wildfly-8.2.0.Final/bin/` then `./standlone.sh`
+.. *Run* Hawkular: `cd dist/target/hawkular-x-y-z-SNAPSHOT/hawkular-x-y-z-SNAPSHOT/bin/` then `./standlone.sh`
 . Run gulp commands within gulp-build directory
 .. *Goto* gulp-build directory: `cd ui/console/target/gulp-build/`
 .. *Run* the gulp watcher: `gulp watch-server`


### PR DESCRIPTION
Changed directory name in dev docs.
Note:
- I didn't change in getting started doc since it referes to the Alpha1 tagged version, will need to be changed with Alpha2 release
- Doc mentions hawkular-x.y.z or hawkular-VERSION, would be good to find a way to use a replacement string so that we can change to the last version in a single place.
