### PR TITLE
Workaround to HAWKULAR-508

### DIFF
--- a/src/main/jbake/content/docs/user/getting-started.adoc
+++ b/src/main/jbake/content/docs/user/getting-started.adoc
@@ -101,7 +101,7 @@ The following assumes that you have Docker installed and started if necessary.
 
 [source, shell]
 ----
-$ docker run -d -p 8081:8080 hawkular/hawkular   #<1>
+$ docker run -d -p 8080:8080 hawkular/hawkular   #<1>
 Unable to find image 'hawkular/hawkular:latest' locally #<2>
 Pulling repository hawkular/hawkular
 26830c504ec5: Download complete
@@ -110,14 +110,14 @@ Pulling repository hawkular/hawkular
 Status: Downloaded newer image for hawkular/hawkular:latest #<3>
 c792a1f059521f6ae99  #<4>
 ----
-<1> Start the docker container in the background (`-d`) and tell it that the internal port 8080 should be
-available as port 8081 (`-p 8081:8080).
+<1> Start the docker container in the background (`-d`) and tell it that the internal (container's) port 8080 should be
+available as host port 8080 (`-p 8080:8080).
 <2> This is the first time that image is to be used, so docker is downloading it from Docker Hub, which may take a
 while. Starting the same image the next time will only take a few seconds.
 <3> Download has finished, Hawkular server will be started
 <4> Hawkular server has started with a container id of `c792a1f0595`. This id will be different for each start.
 
-Now as Docker is running the container and you can reach the Hawkular UI at http://localhost:8081/  ( If you are
+Now as Docker is running the container and you can reach the Hawkular UI at http://localhost:8080/  ( If you are
 running docker on OS/X via boot2docker, you need to use the IP address that is stored in the `DOCKER_HOST`
 environment variable instead of `localhost`.)
 


### PR DESCRIPTION
Setting both ports to `8080` to workaround the https://issues.jboss.org/browse/HAWKULAR-508
Once the `HAWKULAR-508` is fixed, this change can be reverted.
