### PR TITLE
Minor doc update: users should download Wildfly 9.0.1

### DIFF
--- a/src/main/jbake/content/docs/components/alerts/index.adoc
+++ b/src/main/jbake/content/docs/components/alerts/index.adoc
@@ -31,7 +31,7 @@ to build Hawkular Alerts project.
 
 === Wildfly 9
 
-http://wildfly.org/downloads/[Download a Wildfly 9.0.0.Final] archive and expand it somewhere on your disk.
+http://wildfly.org/downloads/[Download a Wildfly 9.0.1.Final] archive and expand it somewhere on your disk.
 
 === Apache Cassandra
 

--- a/src/main/jbake/content/docs/components/metrics/installation.adoc
+++ b/src/main/jbake/content/docs/components/metrics/installation.adoc
@@ -34,7 +34,7 @@ You could also use the Datastax community packages for:
 
 == Installing the server
 
-http://wildfly.org/downloads/[Download a Wildfly 9.0.0.Final] archive and expand it somewhere on your disk.
+http://wildfly.org/downloads/[Download a Wildfly 9.0.1.Final] archive and expand it somewhere on your disk.
 
 Check out the https://github.com/hawkular/hawkular-metrics/releases[Metrics releases] page and download the latest
 version of the web application archive: `hawkular-metrics-api-jaxrs-X.Y.Z.war`


### PR DESCRIPTION
Minor doc update: users should download Wildfly 9.0.1
