### PR TITLE
Website automagic

### DIFF
--- a/.travis.settings.xml
+++ b/.travis.settings.xml
@@ -2,7 +2,6 @@
   <servers>
     <server>
       <id>github</id>
-<!--      <username>${env.CI_DEPLOY_USERNAME}</username>-->
         <password>${env.DEPLOY_TOKEN}</password>
     </server>
   </servers>

--- a/.travis.swagger.sh
+++ b/.travis.swagger.sh
@@ -51,18 +51,18 @@ toc::[]\n\
 }
 
 setHawkularReleasedVersion() {
-  HAWKULAR_RELEASED_VERSION=`curl -Ls https://api.github.com/repos/hawkular/hawkular/releases | grep "tag_name" | head -1 | cut -d '"' -f4`
+  HAWKULAR_RELEASED_VERSION=`curl -Ls -H "Authorization: token $DEPLOY_TOKEN" https://api.github.com/repos/hawkular/hawkular/releases | grep "tag_name" | head -1 | cut -d '"' -f4`
   safelyReplaceUsingFallback "HAWKULAR_RELEASED_VERSION" "x.y.z"
 }
 
 setHawkularReleasedDate() {
-  HAWKULAR_RELEASED_DATE=`curl -Ls https://api.github.com/repos/hawkular/hawkular/releases | grep "published_at" | head -1 | cut -d '"' -f4`
+  HAWKULAR_RELEASED_DATE=`curl -Ls -H "Authorization: token $DEPLOY_TOKEN" https://api.github.com/repos/hawkular/hawkular/releases | grep "published_at" | head -1 | cut -d '"' -f4`
   #HAWKULAR_RELEASED_DATE=`date -d $HAWKULAR_RELEASED_DATE +'%B %-m %Y'`
   safelyReplaceUsingFallback "HAWKULAR_RELEASED_DATE" "month day year"
 }
 
 setHawkularMasterVersion() {
-  HAWKULAR_MASTER_VERSION=`curl -Ls https://raw.githubusercontent.com/hawkular/hawkular/master/pom.xml | grep "^  <version>" | sed -e "s;  <version>\([0-9a-zA-Z\.\-]*\)</version>;\1;"`
+  HAWKULAR_MASTER_VERSION=`curl -Ls -H "Authorization: token $DEPLOY_TOKEN" https://raw.githubusercontent.com/hawkular/hawkular/master/pom.xml | grep "^  <version>" | sed -e "s;  <version>\([0-9a-zA-Z\.\-]*\)</version>;\1;"`
   safelyReplaceUsingFallback "HAWKULAR_MASTER_VERSION" "x.y.z-SNAPSHOT"
 }
 
@@ -82,7 +82,7 @@ downloadAndProcess() {
   DOC_PATH="src/main/jbake/content/docs/rest/"
 
   mkdir -p $DOC_PATH
-  FILES=`curl -Ls https://api.github.com/repos/$REPO/contents/?ref=$BRANCH | grep "download_url.*adoc" | cut -d '"' -f4`
+  FILES=`curl -Ls -H "Authorization: token $DEPLOY_TOKEN" https://api.github.com/repos/$REPO/contents/?ref=$BRANCH | grep "download_url.*adoc" | cut -d '"' -f4`
 
   # travis has sometimes issue with the call above, so make sure it's not empty
   [[ "x" == "x$FILES" ]] && FILES="https://raw.githubusercontent.com/hawkular/hawkular.github.io/swagger/rest-alerts.adoc \

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,8 @@ notifications:
 
 env:
   global:
-    # token used for pushing the built website back to github
-    secure: CHhMe+l5PsSiV9JEUH4Pxqxj/MGpnhwwmD/hp3BuF1c1f8sdrTax7xduNpttJ84Mp3GdEDspfL5sI695/JZU5SqSSIvBxJMEwGtt7/c8gSHdmMdSrpsIgob24D9NIUtrzmqaXRa1Upy7Vll0hs30siOdnxQJKZnjv719Dq+73To=
-
+    # token used for pushing the built website back to github (hawkular-website-bot)
+    secure: "GBXOczQJ6ouFweXASfR+Nnlz2//0cyt7qexj9EkjfxWd1qajN3WaD1aqkEjJwCefiQZh4iHJR7iMVoBHKr4b//7qsuVQ82FjwrVBaJsd2J9AbSnqZLhNV7cQL9gd67UDt9bx33QpJaD4UvjQlKG95dWnoNn1pIsM6J4xdc3XMCA="
 before_install:
   # download all the swagger adoc files
   - bash -x ./.travis.swagger.sh

--- a/pr-auto-deploy/server.sh
+++ b/pr-auto-deploy/server.sh
@@ -29,15 +29,15 @@ deployPr() {
     exit 1
   }
   _base="/tmp/pr$prNo"
-  rm -Rf $_base &> /dev/null ; mkdir -p $_base && cd $_ &&\
+  kill -9 `cat $_base/pid`; rm -Rf $_base &> /dev/null ; mkdir -p $_base && cd $_ &&\
   git clone --single-branch -b pages https://github.com/hawkular/hawkular.github.io &&\
   cd $_base/hawkular.github.io &&\
   git fetch origin refs/pull/$prNo/head:pr$prNo &&\
-  git checkout pr$prNo && rm $_base/fake-input &> /dev/null
-  mkfifo $_base/fake-input
+  git checkout pr$prNo
   [[ -s $_base/pid ]] && kill -9 `cat /tmp/pr$prNo/pid`
   _actual_port=`expr $prNo + $BASE_PORT`
-  cat $_base/fake-input | mvn -Pinline -Djbake.port=$_actual_port -Djbake.listenAddress=0.0.0.0 -Djbake.livereload=false &> /dev/null &
+  mvn &> /dev/null
+  nohup ruby -run -e httpd $_base/hawkular.github.io/target/website -p $_actual_port &> /dev/null &
   PID=$!
   echo $PID > $_base/pid
   echo "kill -9 $PID" | at now + $[DAYS_AVAILABLE*24] hours


### PR DESCRIPTION
:horse: Using the ruby httpd webserver instead of the Winstone for hosting the PRs.

:rabbit: Using the oauth token of hawkular-website-bot (not my own anymore) + adding the auth header with the token for all the REST requests to GitHub.. From time to time, the curls failed because of the GitHub request limit.

wrt :horse: : 
I used the `netcat` for simple client-server bash based RPC, but I must had some issue in it, because the sockets were not closed properly (this issue https://unix.stackexchange.com/questions/10106/orphaned-connections-in-close-wait-state)

I've added killing the orphaned connections in crontab, but this is was not a solution, so I am changing the webserver.. `nohup ruby blahblah &> /dev/null &` looks ok now (it was broken for the Winstone server, because the mvn plugin was expecting the user input + it was wasting with resources because of the file watching feature)

the :rabbit: should actually fix the `x.y.z` occurences instead of the actual version on the http://www.hawkular.org/docs/user/quick-start.html page
