### PR TITLE
Fix broken link to clients page

### DIFF
--- a/src/main/jbake/content/docs/features.adocPart
+++ b/src/main/jbake/content/docs/features.adocPart
@@ -1,7 +1,7 @@
 == Features
 
 === Metric storage
-Hawkular Metrics offers a REST API to store and retrieve metrics. While Hawkular provides some link:clients.html[clients libraries], the same API can be used with any tool, framework or language that supports HTTP communication, such as commands line tools like Curl.
+Hawkular Metrics offers a REST API to store and retrieve metrics. While Hawkular provides some link:clients[clients libraries], the same API can be used with any tool, framework or language that supports HTTP communication, such as commands line tools like Curl.
 
 Three types of metrics are available:
 


### PR DESCRIPTION
Currently the clients link is broken. This just fixes it.
