### PR TITLE
Remove the instruction to start ManageIQ as it already exists in dev setup

### DIFF
--- a/src/main/jbake/content/blog/2016/07/14/hawkular-miq.adoc
+++ b/src/main/jbake/content/blog/2016/07/14/hawkular-miq.adoc
@@ -14,15 +14,9 @@ The functionality to support the Hawkular-Middleware provider is not in the Darg
 You will need to build ManageIQ from their master branch.
 There is a good http://manageiq.org/documentation/development/developer_setup/[guide on developer setup].
 
-Once you are done, you can start ManageIQ like this:
+Once you have completed the instructions, you should have ManageIQ available at
 
-.Start ManageIQ
-[source,shell]
---
-$ bundle exec rake evm:start
---
-
-The server will listen on `http://localhost:3000`.
+`http://localhost:3000`.
 
 == Setup of Hawkular-services
 

--- a/src/main/jbake/content/hawkular-clients/manageiq/docs/quickstart-guide/index.adoc
+++ b/src/main/jbake/content/hawkular-clients/manageiq/docs/quickstart-guide/index.adoc
@@ -14,15 +14,9 @@ The functionality to support the Hawkular-Middleware provider is not in the Darg
 You will need to build ManageIQ from their master branch.
 There is a good http://manageiq.org/documentation/development/developer_setup/[guide on developer setup].
 
-Once you are done, you can start ManageIQ like this:
+Once you have completed the instructions, you should have ManageIQ available at
 
-.Start ManageIQ
-[source,shell]
---
-$ bundle exec rake evm:start
---
-
-The server will listen on `http://localhost:3000`.
+`http://localhost:3000`.
 
 == Setup of Hawkular-services
 


### PR DESCRIPTION
Otherwise users will attempt to start miq twice and will get errors.
