### PR TITLE
Adding the link to the docs generated by yardoc. (~ JavaDoc)

### DIFF
--- a/src/main/jbake/content/hawkular-clients/index.adoc
+++ b/src/main/jbake/content/hawkular-clients/index.adoc
@@ -70,7 +70,7 @@ Hawkular Metrics
 |
 
 |*Ruby*
-|link:https://github.com/hawkular/hawkular-client-ruby/blob/master/README.rdoc[README] / link:http://www.hawkular.org/hawkular-client-ruby/[yardoc]
+|link:https://github.com/hawkular/hawkular-client-ruby/blob/master/README.rdoc[README] / link:./ruby-client-yardoc.html[yardoc]
 |link:https://github.com/hawkular/hawkular-client-ruby[GitHub repository]
 |
 |Metrics API,

--- a/src/main/jbake/content/hawkular-clients/index.adoc
+++ b/src/main/jbake/content/hawkular-clients/index.adoc
@@ -70,7 +70,7 @@ Hawkular Metrics
 |
 
 |*Ruby*
-|link:https://github.com/hawkular/hawkular-client-ruby/blob/master/README.rdoc[README]
+|link:https://github.com/hawkular/hawkular-client-ruby/blob/master/README.rdoc[README] / link:http://www.hawkular.org/hawkular-client-ruby/[yardoc]
 |link:https://github.com/hawkular/hawkular-client-ruby[GitHub repository]
 |
 |Metrics API,

--- a/src/main/jbake/content/hawkular-clients/ruby-client-yardoc.html
+++ b/src/main/jbake/content/hawkular-clients/ruby-client-yardoc.html
@@ -1,0 +1,8 @@
+title=Ruby Client Yardoc
+date=2016-07-18
+type=page
+tags=hawkular, ruby-client
+status=published
+~~~~~~
+
+<iframe src="http://www.hawkular.org/hawkular-client-ruby/" style="border:none;" width="1000" height="1700"></iframe>


### PR DESCRIPTION
Although the url looks pretty similar to this site, it's actually a gh-pages branch on a different repo in the same org => cross site link.

EDIT: http://209.132.178.114:10205/hawkular-clients/  (at the bottom)
