### PR TITLE
String type metrics: limitation configurable

### DIFF
--- a/src/main/jbake/content/hawkular-metrics/docs/user-guide/index.adoc
+++ b/src/main/jbake/content/hawkular-metrics/docs/user-guide/index.adoc
@@ -196,7 +196,7 @@ The String metric type stores any arbitrary strings. Hawkular Metrics already ha
 limited to a predefined number of values which cannot easily be changed. In some cases a String type with arbritrary values
 would better fit for availability events. It can also be used for storing and tracking other types of events.
 
-IMPORTANT: Note that there is a 2 KB limit for string data points.
+IMPORTANT: Note that there is currently a 2 KB limit for string data points. This limitation may be configurable in the future.
 
 === Rate
 A rate is a derived metric whose values are computed from counter or gauge data points. Rate data points can be retrieved for


### PR DESCRIPTION
As discussed on IRC: the limit configuration should be exposed in the future
