### PR TITLE
Metrics: fix code sample not working

### DIFF
--- a/src/main/jbake/content/hawkular-metrics/docs/user-guide/index.adoc
+++ b/src/main/jbake/content/hawkular-metrics/docs/user-guide/index.adoc
@@ -1435,7 +1435,7 @@ specifying a list of metric names.
 [source,shell]
 .Fetch stats from multiple gauges by name
 ----
-curl -X GET http://server/hawkular/metrics/gauges/stats?start=12345&end=56789&buckets=100&metrics=G1,G2,G3
+curl -X GET http://server/hawkular/metrics/gauges/stats?start=12345&end=56789&buckets=100&metrics=G1&metrics=G2&metrics=G3
 ----
 
 This request fetches data points from gauges G1, G2, and G3. The only difference from previous examples is that each
@@ -1485,7 +1485,7 @@ specifying a list of metric names.
 [source,shell]
 .Fetch stats from multiple counters by name
 ----
-curl -X GET http://server/hawkular/metrics/counters/stats?start=12345&end=56789&buckets=100&metrics=C1,C2,C3
+curl -X GET http://server/hawkular/metrics/counters/stats?start=12345&end=56789&buckets=100&metrics=C1&metrics=C2&metrics=C3
 ----
 
 This request fetches data points from counters C1, C2, and C3. The only difference from previous examples is that each
@@ -1535,7 +1535,7 @@ filters or by specifying a list of metric names.
 [source,shell]
 .Fetch rate stats from multiple counters by name
 ----
-curl -X GET http://server/hawkular/metrics/counters/rate/stats?start=12345&end=56789&buckets=100&metrics=C1,C2,C3
+curl -X GET http://server/hawkular/metrics/counters/rate/stats?start=12345&end=56789&buckets=100&metrics=C1&metrics=C2&metrics=C3
 ----
 
 This request fetches rate data points from counters C1, C2, and C3. The only difference from previous examples is that each


### PR DESCRIPTION
List query param in jaxrs need repeating the parameter key n times

Note: I couldn't find it documented in JAXRS doc, but found several resources pointing that (and tested it myself) : 
- http://stackoverflow.com/questions/13750010/jersey-client-how-to-add-a-list-as-query-parameter
- https://www.mkyong.com/webservices/jax-rs/jax-rs-queryparam-example/
