### PR TITLE
Allow an easy way to give us a star on GitHub.

### DIFF
--- a/src/main/jbake/assets/css/base.css
+++ b/src/main/jbake/assets/css/base.css
@@ -36,6 +36,12 @@ body {
   }
 }
 
+.github-stars-btn {
+  width: 50px;
+  height: 20px;
+  vertical-align: bottom;
+}
+
 /* Custom page CSS
 -------------------------------------------------- */
 /* Not required for template or sticky footer method. */

--- a/src/main/jbake/templates/footer.ftl
+++ b/src/main/jbake/templates/footer.ftl
@@ -13,6 +13,7 @@
 				  &copy; 2016 | Hawkular is released under <a href="/license.html">Apache License v2.0</a>
 					<a href="https://twitter.com/hawkular_org" class="twitter-follow-button" data-show-count="false" data-size="medium">Follow @hawkular_org</a>
 				  <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script>
+					<iframe src="https://ghbtns.com/github-btn.html?user=hawkular&repo=hawkular-services&type=star" frameborder="0" scrolling="0" class="github-stars-btn"></iframe>
 				</p>
 
     <!--p id="forkongithubp"><span id="forkongithub">


### PR DESCRIPTION
I am not sure about the `hawkular-metrics` repo to be the repo that obtains all the stars. While logically it should be `hawkular-services`, currently metrics has more stars.

btw. we made a mistake when renaming the hawkular repo to hawkular-dist-old, because we ended up in a state that some abandoned repo has 98 stars. We should have renamed the hawkular to hawkular-services to preserve the stars.
