### PR TITLE
Fix broken link for installing grafana

### DIFF
--- a/src/main/jbake/content/hawkular-services/docs/quickstart-guide/index.adoc
+++ b/src/main/jbake/content/hawkular-services/docs/quickstart-guide/index.adoc
@@ -41,7 +41,7 @@ Now your data is stored in Hawkular Server, in it's distributed Cassandra server
 == Step 2: Read the metrics
 === With Grafana
 At the end of Step 1, you need to trust Hawkular that the data was indeed stored.
-The most elegant way to see the data is by link:/hawkular-clients/grafana/[setting up Grafana and its Hawkular plugin] to actually build a dashboard and look at the `temperature` metric over that day (July 15th 2016) for `myTenant`.
+The most elegant way to see the data is by link:/hawkular-clients/grafana/docs/quickstart-guide/[setting up Grafana and its Hawkular plugin] to actually build a dashboard and look at the `temperature` metric over that day (July 15th 2016) for `myTenant`.
 Here would be the result:
 
 [[img-main]]
@@ -327,4 +327,4 @@ We played with basic metrics and alerting capabilities, both have more advanced 
 
 More details are available in the link:/hawkular-services/docs/user-guide/[Hawkular Services user guide] and the various REST APIs documentations: link:/docs/rest/rest-alerts.html[Alerting REST API], link:/docs/rest/rest-metrics.html[Metrics REST API] and link:/docs/rest/rest-inventory.html[Inventory REST API]
 
-Note that multiple client libraries have been written already, and some agents that can collect or listen to metrics to feed the system. Have a look at the link:/hawkular-clients/[clients page] to see what it supported as of today (We love contributions!) 
+Note that multiple client libraries have been written already, and some agents that can collect or listen to metrics to feed the system. Have a look at the link:/hawkular-clients/[clients page] to see what it supported as of today (We love contributions!)


### PR DESCRIPTION
It was linking to the old page which is now deleted
