### PR TITLE
Replace the Titan config props with the SQL config props available

### DIFF
--- a/src/main/jbake/content/hawkular-services/docs/user-guide/inventory/index.adoc
+++ b/src/main/jbake/content/hawkular-services/docs/user-guide/inventory/index.adoc
@@ -375,7 +375,7 @@ retries of transactions if they fail due to locking or concurrent access
 situations.
 
 |`hawkular.inventory.tinkerpop.graph-provider-impl`
-|Inventory implementation based on Tinkerpop2 API (the default)
+|Inventory implementation based on Tinkerpop3 API (the default)
 |`HAWKULAR_INVENTORY_TINKERPOP_GRAPH_PROVIDER_IMPL`
 |_undefined_
 |The fully qualified class name of an implementation of the
@@ -384,88 +384,32 @@ situations.
 Tinkerpop is an API that is implemented by multiple graph databases. This
 property can be used to override the default selection mechanism that is to use
 the first implementation loaded using the Java services mechanism. Hawkular is
-by default packaged with http://thinkaurelius.github.io/titan/[Titan].
+by default packaged with https://github.com/pietermartin/sqlg[Sqlg].
 
-|`storage.hostname` (system property
-`hawkular.inventory.titan.storage.hostname`)
-|Titan graph provider used (which is the default)
-|`HAWKULAR_INVENTORY_TITAN_STORAGE_HOSTNAME` or `CASSANDRA_NODES`
-|127.0.0.1
-|The host for contacting backend storage for Titan. Because Titan in Hawkular
-by default uses Cassandra which is also used by Metrics, the `CASSANDRA_NODES`
-environment variable is recognized by both components.
-
-|`storage.port` (system property `hawkular.inventory.titan.storage.port`)
-|Titan graph provider used (which is the default)
-|`HAWKULAR_INVENTORY_TITAN_STORAGE_PORT`
+|`sql.jdbc.url` (system property `hawkular.inventory.sql.jdbc.url`)
+|The connection string to the database to store inventory data to.
+|`HAWKULAR_INVENTORY_SQL_JDBC_URL`
 |_undefined_
-|This is the port to connect to the Titan storage backend. The default value
-is dependent on the storage chosen. For Cassandra, this is `9160` which is the
-default Thrift API port.
+|The connection string to the database that will be used to store inventory data to.
 
-|`storage.cassandra.keyspace` (system property
-`hawkular.inventory.titan.storage.cassandra.keyspace`)
-|Titan graph provider used (which is the default)
-|`HAWKULAR_INVENTORY_TITAN_STORAGE_CASSANDRA_KEYSPACE`
-|`hawkular_inventory`
-|The Cassandra keyspace to use for storing inventory data through Titan.
+If the connection string starts with `jndi:`, the remainder of the connection string is understood to be the object
+name of a datasource accessible in the JNDI tree of the Hawkular server (e.g. the default
+`jndi:java:/jboss/datasources/HawkularInventoryDS_hsqldb`). Otherwise this can be a connection string to any database
+supported by Sqlg. As of the time of writing, this is Postgresql, H2 and HSQLDB (e.g.
+`jdbc:postgresql://localhost/hawkular`). In the case of a "normal" JDBC connection, it will usually be necessary to
+also provide the username and password. If the connection is obtained from JNDI there is no need to provide the
+credentials.
 
-5+e|The configuration file can also contain any other configuration option
-specific for the Titan backend. Please consult the
-http://s3.thinkaurelius.com/docs/titan/current/titan-config-ref.html[Titan configuration].
+|`sql.jdbc.username` (system property `hawkular.inventory.sql.jdbc.username`)
+|The user name to use when connecting using a normal JDBC connection.
+|`HAWKULAR_INVENTORY_SQL_JDBC_USERNAME`
+|_undefined_
+|The user name to use when connecting using a normal JDBC connection.
 
-You can also consult the
-https://github.com/hawkular/hawkular-inventory/blob/master/hawkular-integrated-inventory-rest/src/main/resources/hawkular-inventory.properties[default configuration]
-of the default inventory deployment (using Titan with Cassandra backend).
+|`sql.jdbc.password` (system property `hawkular.inventory.sql.jdbc.password`)
+|The password to use when connecting using a normal JDBC connection.
+|`HAWKULAR_INVENTORY_SQL_JDBC_PASSWORD`
+|_undefined_
+|The password to use when connecting using a normal JDBC connection.
 
 |====
-
-++++
-</div>
-++++
-
-[[rest-api]]
-== REST API
-
-While the main, generated, REST API documentation is present
-link:../../rest/rest-inventory.html[here], in here we discuss some aspects of
-the API that are not well described in the docs generated from the code.
-
-=== Paths
-As mentioned in <<basic-principles, Basic Principles>> entities can only be
-uniquely defined by their paths, not just IDs.
-
-In REST API, such paths are inlined in the URL address like in the following
-example:
-
-  http://my.host/hawkular/inventory/tenant/env/res/metrics/../metric
-
-The above URL means that we want to check if the resource `res` incorporates
-a metric called `metric` that is located in the same environment. I.e. the path
-to the metric is expressed as a relative path to the resource.
-
-For example, if one wanted to relate to a metric in another environment, one
-would use a URL similar to this one:
-
-  http://my.host/hawkular/inventory/tenant/env/res/metrics/../../env2/metric
-
-Notice that one needn't to specify the type in the path segments, contrary to
-what was shown in <<basic-principles, Basic Principles>>. This is because
-the REST API is trying to infer the type from what type is being looked for and
-the current "location" of the entity to which the path is relative.
-
-The inference mechanism is quite powerful but some relative paths are inherently
-ambiguous without specific type information so there will be situations where
-the type specifier in some of the segments will need to be provided like this:
-
-  http://my.host/hawkular/inventory/tenant/env/res/metrics/../../e;env2/metric
-
-In <<basic-principles, Basic Principles>> the canonical path is described to
-start with a tenant ID. While technically that is true, the REST API presents
-and receives the paths WITHOUT the tenant id. This is because the REST API
-deduces the tenant ID from the authentication information in the request.
-
-Thus, when you pass canonical paths to the REST API, don't start it with the
-tenant ID, but with the path segment following it. The paths returned from the
-REST API will not contain the tenant ID either.
-


### PR DESCRIPTION
as of 0.19.3.Final.

Also remove the section about REST API that is no longer applicable.

Don't merge this until inventory `0.19.3.Final` is released.
