### PR TITLE
Fix wrong release version for grafana plugin

### DIFF
--- a/src/main/jbake/content/blog/2016/10/24/hawkular-metrics-openshift-and-grafana.adoc
+++ b/src/main/jbake/content/blog/2016/10/24/hawkular-metrics-openshift-and-grafana.adoc
@@ -56,7 +56,7 @@ endif::[]
 
 === Setup Hawkular Datasource in Grafana
 
-So now, let's have a look at Grafana. For this article I've installed a recent version (3.1.1) and the link:https://github.com/hawkular/hawkular-grafana-datasource[Hawkular Datasource plugin] (1.0.2).
+So now, let's have a look at Grafana. For this article I've installed a recent version (3.1.1) and the link:https://github.com/hawkular/hawkular-grafana-datasource[Hawkular Datasource plugin] (1.0.3).
 
 In Grafana, to configure the Hawkular Datasource, set the URL of the Metrics service in OpenShift, ending with _/hawkular/metrics_. You should have something similar to _https://metrics.192.168.42.63.xip.io/hawkular/metrics_. Access mode must be _Proxy_. The tenant must be the name of the project in OpenShift where we've created our sample application; so for my example here, it's just "test". And finally, put the bearer token for the OpenShift API access. To generate a token, you can navigate to _/oauth/token/request_ from your OpenShift base path (something like _https://192.168.42.63:8443/oauth/token/request_).
 


### PR DESCRIPTION
I did a mistake when releasing 1.0.2, the good one is 1.0.3
