### PR TITLE
Grafana quickstart: do not limit rows

### DIFF
--- a/src/main/jbake/content/hawkular-clients/grafana/docs/quickstart-guide/index.adoc
+++ b/src/main/jbake/content/hawkular-clients/grafana/docs/quickstart-guide/index.adoc
@@ -7,7 +7,7 @@ Thomas Heute
 :icons: font
 :toc: macro
 :toc-title:
-
+:imagesdir: https://raw.githubusercontent.com/hawkular/hawkular-grafana-datasource/master/
 
 :leveloffset: 1
-include::https://raw.githubusercontent.com/hawkular/hawkular-grafana-datasource/master/README.adoc[lines=9..100]
+include::https://raw.githubusercontent.com/hawkular/hawkular-grafana-datasource/master/README.adoc[]


### PR DESCRIPTION
Fixes broken design on grafana plugin. Include eveything from github readme
