### PR TITLE
Unlink grafana guide from GH

### DIFF
--- a/src/main/jbake/content/hawkular-clients/grafana/docs/quickstart-guide/index.adoc
+++ b/src/main/jbake/content/hawkular-clients/grafana/docs/quickstart-guide/index.adoc
@@ -50,7 +50,32 @@ Select the tenant. On Hawkular servers, use `hawkular`.
 
 Openshift-Metrics users must provide an authentication token.
 
-== Using Grafana Templating (variables)
+== Usage
+
+=== Queries
+
+When adding a Graph panel, the Metrics tab allows you fetch _Gauges_ and _Counters_ metrics in Hawkular. You can either search by metric id or by tag.
+
+When searching by id, you must provide the exact metric id (or use variables, as discussed later).
+
+image::docs/images/search-by-name.png[caption="Example of query by name"]
+
+When searching by tag, you must provide the tag key, followed by its value or any pattern recognized by Hawkular Metrics. Check how link:http://www.hawkular.org/hawkular-metrics/docs/user-guide/#_tag_filtering[tagging works in Hawkular].
+
+- To add more tag filters, hit the "+" button and repeat the process.
+- To remove a tag, click on its key and select "Remove tag".
+
+image::docs/images/search-by-tag.png[caption="Example of query by tag"]
+
+TIP: Note that querying by tag may return multiple series for a single query, as illustrated above.
+
+When using a _Singlestat_ panel, some additional options come in. The Hawkular Datasource plugin can perform aggregations on multiple metrics, which usually the _Singlestat_ panel doesn't. It's actually a two-steps aggregation: first, multiple series are reduced into a single one (that is either the sum of its parts, or the average). Then, the resulting series is aggregated over time through another folding: min, max, average etc.
+
+image::docs/images/single-stats-aggreg.png[caption="Example of singlestat panel"]
+
+TIP: Note that because the aggregation takes place in Hawkular, the _Singlestat_ panel has nothing to aggregate. Thus in panel options, setting whatever in the _value_ field on the _Big value_ won't have any effect. However if you don't want to use the Hawkular aggregation, just set _Multiple series aggregation_ to _None_.
+
+=== Templating variables
 
 Grafana allows you to create dashboard templates through the definition of variables. This is link:http://docs.grafana.org/reference/templating/[documented on Grafana's site].
 With the Hawkular Datasource Plugin, the variables of type _'Query'_ are mapped to the http://www.hawkular.org/docs/rest/rest-metrics.html#GET__metrics[_@get (url)/metrics_]
@@ -59,7 +84,7 @@ Hawkular Metrics endpoint and can be used to retrieve tenant's metric names. Use
 image::docs/images/query-for-metrics.png[caption="Example of query by tags to get metric ids", width="600"]
 
 [TIP]
-For instance, if you have metrics tagged _"type:memory"_ and others tagged _"type:cpu"_, you can write _"?tags=type:memory"_ to get only the _"memory"_ ones, or _"?tags=type:cpu|memory"_ to get them both. The leading question mark is not mandatory.
+For instance, if you have metrics tagged _"type:memory"_ and others tagged _"type:cpu"_, you can write _"tags=type:memory"_ to get only the _"memory"_ ones, or _"tags=type:cpu|memory"_ to get them both.
 
 There is an exception to that rule: if the query string is prefixed with _'tags/'_, the variable will contain the matching tag names rather than the metric names. In this case, the Hawkular Metrics endpoint link:++http://www.hawkular.org/docs/rest/rest-metrics.html#GET__metrics_tags__tags_++[_@get (url)/metrics/tags/{tags}_] will be used.
 

--- a/src/main/jbake/content/hawkular-clients/grafana/docs/quickstart-guide/index.adoc
+++ b/src/main/jbake/content/hawkular-clients/grafana/docs/quickstart-guide/index.adoc
@@ -8,6 +8,88 @@ Thomas Heute
 :toc: macro
 :toc-title:
 :imagesdir: https://raw.githubusercontent.com/hawkular/hawkular-grafana-datasource/master/
+:source-language: javascript
 
-:leveloffset: 1
-include::https://raw.githubusercontent.com/hawkular/hawkular-grafana-datasource/master/README.adoc[]
+This project is the Hawkular Datasource plugin for Grafana 3. It works with:
+
+* Metrics standalone servers as well
+* Hawkular servers, starting from version Alpha13
+
+== Installing
+
+NOTE: If you don't have Grafana yet, link:http://grafana.org/download/[download and install it].
+
+=== From source
+
+Download the source code and copy the content of `dist` to `hawkular` inside Grafana's plugin directory:
+
+[source,bash]
+----
+# This is the default for Linux Grafana installs. Change it to match yours, if needed.
+GRAFANA_PLUGINS=/var/lib/grafana/plugins
+wget https://github.com/hawkular/hawkular-grafana-datasource/archive/release.zip -O hawkular-grafana-datasource-release.zip
+unzip hawkular-grafana-datasource-release.zip
+mkdir ${GRAFANA_PLUGINS}/hawkular
+cp -R hawkular-grafana-datasource-release/dist/* ${GRAFANA_PLUGINS}/hawkular
+----
+
+=== From the Grafana plugin directory
+
+COMING SOON
+
+== Configuration
+
+The datasource URL must point to the Hawkular Metrics service, e.g. `http://myhost:8080/hawkular/metrics`
+
+`direct` access mode only works with standalone Metrics servers currently. If you active it, make sure to allow
+the Grafana server origin in Metrics' configuration.
+
+Authentication must be set when working with a Hawkular server. Check the 'Basic Auth' box and fill the user and password fields.
+
+Select the tenant. On Hawkular servers, use `hawkular`.
+
+Openshift-Metrics users must provide an authentication token.
+
+== Using Grafana Templating (variables)
+
+Grafana allows you to create dashboard templates through the definition of variables. This is link:http://docs.grafana.org/reference/templating/[documented on Grafana's site].
+With the Hawkular Datasource Plugin, the variables of type _'Query'_ are mapped to the http://www.hawkular.org/docs/rest/rest-metrics.html#GET__metrics[_@get (url)/metrics_]
+Hawkular Metrics endpoint and can be used to retrieve tenant's metric names. Use the _Query Options_ text field to pass query parameters, as illustrated below:
+
+image::docs/images/query-for-metrics.png[caption="Example of query by tags to get metric ids", width="600"]
+
+[TIP]
+For instance, if you have metrics tagged _"type:memory"_ and others tagged _"type:cpu"_, you can write _"?tags=type:memory"_ to get only the _"memory"_ ones, or _"?tags=type:cpu|memory"_ to get them both. The leading question mark is not mandatory.
+
+There is an exception to that rule: if the query string is prefixed with _'tags/'_, the variable will contain the matching tag names rather than the metric names. In this case, the Hawkular Metrics endpoint link:++http://www.hawkular.org/docs/rest/rest-metrics.html#GET__metrics_tags__tags_++[_@get (url)/metrics/tags/{tags}_] will be used.
+
+image::docs/images/query-for-tags.png[caption="Example of query to get matching tag values", width="600"]
+
+[TIP]
+For instance, type _"tags/type:*"_ to get all of the available tag values for _"type"_.
+
+Once you have set some variables, you can use them in graph queries: either for row or graph duplication, or to display multiple series in a single graph from a single query. This is especially useful when metric names contain some dynamic parts and thus cannot be known in advance.
+
+== Building
+
+You need `npm` and `grunt` to build the project.
+Clone [the repository from github](https://github.com/hawkular/hawkular-grafana-datasource), then from that directory run:
+
+[source,bash]
+----
+npm install
+grunt
+----
+
+Files are generated under the `dist` directory.
+To test your build, copy these files to `${GRAFANA_PLUGINS}/hawkular` and restart grafana-server.
+
+== Building and running a Docker image
+
+[source,bash]
+----
+# This will build the image
+docker build -t hawkular/hawkular-grafana-datasource .
+# This will run the image on http://localhost:3000/
+docker run -i -p 3000:3000 --name hawkular-grafana-datasource --rm hawkular/hawkular-grafana-datasource
+----


### PR DESCRIPTION
The new GH readme is dedicated to the grafana plugin registry, so there are less information on installing / building from sources.
For the hawkular site, the documentation is now fully hosted here. There is some duplicated parts however (chapters on usage)

Note: some images depend on https://github.com/hawkular/hawkular-grafana-datasource/pull/29
So we should merge the other one first.