### PR TITLE
Grafana quick start: update docker instructions

### DIFF
--- a/src/main/jbake/content/hawkular-clients/grafana/docs/quickstart-guide/index.adoc
+++ b/src/main/jbake/content/hawkular-clients/grafana/docs/quickstart-guide/index.adoc
@@ -114,12 +114,23 @@ grunt
 Files are generated under the `dist` directory.
 To test your build, copy these files to `${GRAFANA_PLUGINS}/hawkular` and restart grafana-server.
 
-== Building and running a Docker image
+== Running with Docker
+
+Docker images are available on docker hub: https://hub.docker.com/r/hawkular/hawkular-grafana-datasource/
+
+To run it:
+
+[source,bash]
+----
+# This will run the image on http://localhost:3000/
+docker run -i -p 3000:3000 --name hawkular-grafana-datasource --rm hawkular/hawkular-grafana-datasource:latest
+----
+
+To build the docker image with the latest git release:
 
 [source,bash]
 ----
 # This will build the image
-docker build -t hawkular/hawkular-grafana-datasource .
-# This will run the image on http://localhost:3000/
-docker run -i -p 3000:3000 --name hawkular-grafana-datasource --rm hawkular/hawkular-grafana-datasource
+cd docker
+./build.sh
 ----


### PR DESCRIPTION
- Mention public repository
- Building the docker image pulls the latest release