### PR TITLE
Improve tag display

### DIFF
--- a/src/main/jbake/templates/page.ftl
+++ b/src/main/jbake/templates/page.ftl
@@ -6,7 +6,9 @@
         <div class="container">
           <h1><#escape x as x?xml>${content.title}</#escape></h1>
           <p><#if (content.description)??><#escape x as x?xml>${content.description}</#escape><#else></#if></p>
+        <#include "tags_on_page.ftl">
         </div>
+
       </section>
 
 	<!--<p><em>${content.date?string("dd MMMM yyyy")}</em></p>-->
@@ -16,16 +18,5 @@
         ${content.body}
       </div>
     </section>
-    <#if (content.tags)?? >
-<div class="container">
-      <p><strong>Tags:</strong> 
-        <#list content.tags as tag>
-          <#if tag != "blog">
-            | <a href="/tags/${tag}.html">${tag}</a> 
-          </#if>
-        </#list>
-         | </p>
-      </div>  
-    </#if>    
 
 <#include "footer.ftl">

--- a/src/main/jbake/templates/post.ftl
+++ b/src/main/jbake/templates/post.ftl
@@ -6,15 +6,7 @@
         <div class="container">
             <h1><#escape x as x?xml>${content.title}</#escape></h1>
             <p>A blog post by ${content.author}</p>
-        <#if (content.tags)??>
-            <p><strong>Tags:</strong> 
-            <#list content.tags as tag>
-              <#if tag != "blog">
-               | <a href="/tags/${tag}.html">${tag}</a> 
-              </#if>
-            </#list> |</p>
-        </#if>    
-            
+        <#include "tags_on_page.ftl">            
         </div>
     </section>
 

--- a/src/main/jbake/templates/show_all_tags.ftl
+++ b/src/main/jbake/templates/show_all_tags.ftl
@@ -4,9 +4,13 @@
   <#assign tmp_list = tmp_list + [ tag ] />
 </#list>  
 <#assign the_tags = tmp_list?sort />
+<#assign i = 0>
 <#list the_tags as tag>
-|  <a href="/tags/${tag}.html">${tag}</a> 
+  <a href="/tags/${tag}.html">${tag}</a> 
+    <#if (i < the_tags?size-1)>
+        |
+    </#if>
+    <#assign i = i+1 >  
 </#list>  
- |
 </div>
 

--- a/src/main/jbake/templates/tags_on_page.ftl
+++ b/src/main/jbake/templates/tags_on_page.ftl
@@ -1,15 +1,19 @@
 <!-- show tags for this page -->
 <#if (content.tags)??>
+  <#assign tmp_list = [] />
+  <#list content.tags as tag>
+    <#if tag != "blog">
+      <#assign tmp_list = tmp_list + [ tag ] />
+    </#if>  
+  </#list>
   <#assign i = 0>
    <p> 
-    <#list content.tags as tag>
-      <#if tag != "blog">
-        <a href="/tags/${tag}.html">${tag}</a> 
-        <#if (i < content.tags?size-1)>
+    <#list tmp_list as tag>
+      <a href="/tags/${tag}.html">${tag}</a> 
+      <#if (i < tmp_list?size-1)>
           |
-        </#if>
-        <#assign i = i+1 >  
       </#if>
+      <#assign i = i+1 >  
     </#list> 
   </p>
 </#if>    

--- a/src/main/jbake/templates/tags_on_page.ftl
+++ b/src/main/jbake/templates/tags_on_page.ftl
@@ -1,0 +1,15 @@
+<!-- show tags for this page -->
+<#if (content.tags)??>
+  <#assign i = 0>
+   <p> 
+    <#list content.tags as tag>
+      <#if tag != "blog">
+        <a href="/tags/${tag}.html">${tag}</a> 
+        <#if (i < content.tags?size-1)>
+          |
+        </#if>
+        <#assign i = i+1 >  
+      </#if>
+    </#list> 
+  </p>
+</#if>    


### PR DESCRIPTION
Put tags on pages on the top.
Don't surround the (list of) tags by `|` anymore