### PR TITLE
Include Alerting User Guide under Metrics

### DIFF
--- a/src/main/jbake/templates/navigation.ftl
+++ b/src/main/jbake/templates/navigation.ftl
@@ -79,7 +79,10 @@
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown">Documentation</a>
                       <ul class="dropdown-menu">
                         <li class="menu-item ">
-                          <a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>hawkular-metrics/docs/user-guide/">User Guide</a>
+                          <a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>hawkular-metrics/docs/user-guide/">Metrics User Guide</a>
+                        </li>
+                        <li class="menu-item ">
+                            <a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>community/docs/developer-guide/alerts.html">Alerting User Guide</a>
                         </li>
                         <li class="menu-item ">
                           <a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>docs/rest/rest-metrics.html">Metrics REST API</a>


### PR DESCRIPTION
@stefannegrea @jshaughn as discussed, this is the proposal to include the Alerting User Guide under Metrics menu. Otherwise is far on navigation and feedback from users is that information is hard to find.
Note that links to the content are not modified as those are used in several places (examples,code reference,blogs) and we do not want to create broken links.