### PR TITLE
Show the preamble for blog posts.

### DIFF
--- a/src/main/jbake/assets/css/styles.css
+++ b/src/main/jbake/assets/css/styles.css
@@ -7326,7 +7326,7 @@ table.tableblock > tbody > tr:nth-child(odd) {
 }
 
 @media (max-width: 991px) {
-  #preamble {
+  .container #preamble {
     display:none;
   }
 


### PR DESCRIPTION
Hide the generated preamble (that is used as ToC - left hand side navigation) on small devices only within the container div (not in the blog context).