### PR TITLE
Add Alerting into navigation menu

### DIFF
--- a/.travis.swagger.sh
+++ b/.travis.swagger.sh
@@ -85,7 +85,8 @@ downloadAndProcess() {
   FILES=`curl -Ls -H "Authorization: token $DEPLOY_TOKEN" https://api.github.com/repos/$REPO/contents/?ref=$BRANCH | grep "download_url.*adoc" | cut -d '"' -f4`
 
   # travis has sometimes issue with the call above, so make sure it's not empty
-  [[ "x" == "x$FILES" ]] && FILES="https://raw.githubusercontent.com/hawkular/hawkular.github.io/swagger/rest-alerts.adoc \
+  [[ "x" == "x$FILES" ]] && FILES="https://raw.githubusercontent.com/hawkular/hawkular.github.io/swagger/rest-alerts-v1.adoc \
+https://raw.githubusercontent.com/hawkular/hawkular.github.io/swagger/rest-alerts-v2.adoc \
 https://raw.githubusercontent.com/hawkular/hawkular.github.io/swagger/rest-btm.adoc \
 https://raw.githubusercontent.com/hawkular/hawkular.github.io/swagger/rest-datamining.adoc \
 https://raw.githubusercontent.com/hawkular/hawkular.github.io/swagger/rest-inventory.adoc \

--- a/src/main/jbake/templates/navigation.ftl
+++ b/src/main/jbake/templates/navigation.ftl
@@ -97,6 +97,27 @@
                     </li>
                   </ul>
                 </li>
+                <li class="dropdown">
+                  <a aria-expanded="false" class="dropdown-toggle" data-toggle="dropdown" href="#" role="button">
+                    Hawkular Alerting<span class="caret"></span>
+                  </a>
+                  <ul class="dropdown-menu" role="menu">
+                  <li class="menu-item dropdown dropdown-submenu">
+                    <a href="#" class="dropdown-toggle" data-toggle="dropdown">Documentation</a>
+                      <ul class="dropdown-menu">
+                        <li class="menu-item ">
+                            <a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>community/docs/developer-guide/alerts.html">Alerting User Guide</a>
+                        </li>
+                        <li class="menu-item ">
+                          <a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>docs/rest/rest-alerts.html">Alerting REST API</a>
+                        </li>
+                      </ul>
+                  </li>
+                    <li>
+                      <a href="https://github.com/hawkular/hawkular-alerts/releases/">Download</a>
+                    </li>
+                  </ul>
+                </li>
                 <li><a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>hawkular-clients/">Hawkular Clients</a></li>
                 <li class="dropdown"><a aria-expanded="false" class="dropdown-toggle" data-toggle="dropdown" href="#" role="button">
                   Community


### PR DESCRIPTION
Hawkular Alerting project is close to release a 2.x which has focus on federated scenarios running as standalone scenarios.
We might want to differenciate v1 and v2 API and doc, as some features will be only on v2 onward (i.e. integration with Prometheus/Kafka or changes on API).

So, as a previous step to split this documentation and not introduce noise to potential users of v2, Hawkular Alerting should be placed also in the navigational menu where we create a v1/v2 entries for API and docs.