### PR TITLE
Update dev guide rest-api links to be versioned appropriately.

### DIFF
--- a/src/main/jbake/content/community/docs/developer-guide/alerts-v1.adoc
+++ b/src/main/jbake/content/community/docs/developer-guide/alerts-v1.adoc
@@ -874,5 +874,5 @@ Url can be a list of valid link:https://hc.apache.org/httpcomponents-core-ga/htt
 
 Hawkular Alerting supports a robust REST API for managing Triggers, Alerts and Events.
 
-* link:http://www.hawkular.org/docs/rest/rest-alerts.html[Hawkular Alerting REST API]
+* link:http://www.hawkular.org/docs/rest/rest-alerts-v1.html[Hawkular Alerting REST API]
 

--- a/src/main/jbake/content/community/docs/developer-guide/alerts-v2.adoc
+++ b/src/main/jbake/content/community/docs/developer-guide/alerts-v2.adoc
@@ -13,6 +13,8 @@ toc::[]
 
 == Introduction
 
+TIP: Using Hawkular Alerting 1.x?  See the Version 1 Developer Guide link:alerts-v1.html[here].
+
 Hawkular Alerting is a component of the http://hawkular.org[Hawkular] management and monitoring project. It's goal is to provide flexible and scalable alerting services in an easily consumable way.
 
 The Hawkular Alerting project lives on http://github.com/hawkular/hawkular-alerts[GitHub].
@@ -874,5 +876,5 @@ Url can be a list of valid link:https://hc.apache.org/httpcomponents-core-ga/htt
 
 Hawkular Alerting supports a robust REST API for managing Triggers, Alerts and Events.
 
-* link:http://www.hawkular.org/docs/rest/rest-alerts.html[Hawkular Alerting REST API]
+* link:http://www.hawkular.org/docs/rest/rest-alerts-v2.html[Hawkular Alerting REST API]
 


### PR DESCRIPTION
 Also, add v1 dev guide link at top of v2 guide.