### PR TITLE
Cleanup hawkular.org to remove bad info and make good info more accessible

### DIFF
--- a/src/main/jbake/assets/css/styles.css
+++ b/src/main/jbake/assets/css/styles.css
@@ -3864,7 +3864,7 @@ select[multiple].input-group-sm > .input-group-btn > .btn {
 }
 .navbar-fixed-top {
   padding-bottom: 12px;
-  padding-top: 12px;
+#  padding-top: 12px;
 }
 .navbar-collapse {
   overflow-x: visible;
@@ -6450,7 +6450,7 @@ table {
 .main-banner {
 /*   background: #ca0612 url(../img/banner-bg.jpg) repeat-x left top; */
   background: #18181a url(../img/banner-bg-hawkular.svg) no-repeat center center;
-  color: #fff;
+  color: red;
   padding: 60px 0;
 }
 @media (max-width: 640px) {

--- a/src/main/jbake/content/overview/index.adoc
+++ b/src/main/jbake/content/overview/index.adoc
@@ -12,8 +12,3 @@ toc::[]
 
 include::what-is-hawkular.adocPart[]
 
-include::hawkular-projects.adocPart[]
-
-include::concepts.adocPart[]
-
-include::features.adocPart[]

--- a/src/main/jbake/content/overview/what-is-hawkular.adocPart
+++ b/src/main/jbake/content/overview/what-is-hawkular.adocPart
@@ -2,22 +2,13 @@
 
 === What is Hawkular ?
 
-It's a hawk with a monocular. Hawks are known to have a very sharp vision and very good hunters, they can catch preys anticipating their movements at a very fast speed.
-The analogy with this project is our goal is to be able to monitor things and catch anomalies in fast pace environments.
+Hawkular is a set of Open Source (Apache License v2) projects designed to be a generic solution for common monitoring problems. The Hawkular projects provide REST services that can be used for all kinds of monitoring needs. Our aim is to provide a generic solution that can be used for common monitoring problems.
 
-The project started around the end of 2014 as a successor of the http://www.rhq-project.org[RHQ Project].
+Our project goal is to be able to monitor fast paced environments and catch anomalies quickly. Since hawks are known to have very sharp vision and as very good hunters, anticipating their prey’s movement even at high speeds, our project logo is a hawk with a monocle.
 
-It's a set of few opensource (Apache License v2) projects targeted for monitoring solutions and is sponsored by http://www.redhat.com[Red Hat].
-Those projects provide REST services for all kind of monitoring needs.
-From collecting rain sensors data and send an SMS on rain, to monitor docker containers or do Application Performance Monitoring, we aim at providing a generic solutions to common problems.
+The project started around the end of 2014 as a successor of the RHQ Project. The Hawkular project is sponsored by Red Hat. The monitoring services provided by Hawkular have been adopted by different projects and are central to the Middleware management solution in the ManageIQ project.
 
-The monitoring services provided by Hawkular are adopted by different projects and central to the Middleware management solution in the http://www.manageiq.org[ManageIQ] project.
+=== Who is Hawkular for ?
 
-=== For who ?
+The main goal of the Hawkular organization is to provide tools to monitor, view, predict, and guide you to make informed decisions about deployed applications and infrastructure.  Anyone looking for Java-based components for alerting, metric storage, or distributed tracing should be interested in Hawkular.  For those interested in centralized management of their entire stack, ManageIQ should be of interest.  ManageIQ depends on Hawkular components in its middleware management provider.
 
-- IoT entusiast who needs to collect metrics and possibly need to trigger alerts
-- Operators who are looking for a solution to store metrics from statsD, collectd, syslog...
-- Developers of solutions who need long term timeseries database storage
-- Users of http://www.manageiq.org[ManageIQ] who are looking for Middleware management
-- Users of Kubernetes/Heapster who wants to store docker container metrics in a long term timeseries database storage, thanks to the Heapster sink for Hawkular.
-- ...

--- a/src/main/jbake/templates/header.ftl
+++ b/src/main/jbake/templates/header.ftl
@@ -35,12 +35,4 @@
     <#if head_extras??>${head_extras}</#if>
   </head>
   <body onload="prettyPrint()" data-spy="scroll" data-offset="80" data-target="#toc">
-    <div id="wrap">
-      <div class="dropup">
-        <a class="tabnav-closed" href="#" id="tab">Red Hat</a>
-        <script>
-            window.addEventListener('load', function() {
-                 renderTabzilla("Hawkular", "https://hawkular.github.io", true );
-            }, false);
-        </script>
-      </div>
+

--- a/src/main/jbake/templates/index.ftl
+++ b/src/main/jbake/templates/index.ftl
@@ -8,47 +8,51 @@
             Open Source Monitoring Components
           </h1>
           <div class="buttons fade-in two">
-            <a class="btn btn-primary btn-lg" href="/overview/">Overview</a>
-            <a class="btn btn-default btn-lg" href="/hawkular-services/docs/quickstart-guide/">Get Started!</a>
+            <a class="btn btn-primary btn-lg" href="/overview/">Hawkular Overview</a>
           </div>
-          <!--p class="version fade-in three"><i class="fa fa-list-ul"></i><span class="latestVersion"/>
-          </p-->
         </div>
     </section>
     <section class="main-features">
         <div class="container">
-            <h2>Hawkular Features</h2>
             <div class="row">
                 <ul>
-                    <li class="col-md-4 col-sm-4">
-                        <a href="/overview/index.html#_metric_storage"><i class="fa fa-cloud"></i></a>
-                        <h4>Metric Storage</h4>
-                        <p>Flexible, scalable and high performance metric storage based on Cassandra. <a href="/overview/index.html#_metric_storage">More...</a></p>
-                    </li>
-                    <li class="col-md-4 col-sm-4">
+                    <li class="col-md-3">
+                        <h3>Federated Alerting</h3>
                         <a href="/overview/index.html#_alerting"><i class="fa fa-bell"></i></a>
-                        <h4>Alerting</h4>
-                        <p>Notify administrators of performance problems or other user defined conditions. <a href="/overview/index.html#_alerting">More...</a></p>
+                        <p class="text-left">H-Alerts integrates with Prometheus, Elastic, Kafka and you.</p>
+                        <p class="text-left"><a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>community/docs/developer-guide/alerts-v2.html">About</a></p>
+                        <p class="text-left"><a href="http://hub.docker.com/r/hawkular/hawkular-alerts/">Download</a></p>
+                        <p class="text-left"><a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>community/docs/developer-guide/alerts-v2.html">User Guide</a></p>
+                        <p class="text-left"><a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>docs/rest/rest-alerts-v2.html">REST API Guide</a></p>
+                        <p class="text-left"><a href="http://github.com/hawkular/hawkular-alerts/tree/master/examples/tutorial">Tutorial</a></p>
+                        <p class="text-left"><a href="http://github.com/hawkular/hawkular-alerts/tree/master/examples">Examples</a></p>
+                        <p class="text-left"><a href="http://github.com/hawkular/hawkular-alerts">Github</a></p>
                     </li>
-                    <li class="col-md-4 col-sm-4">
-                        <a href="/overview/index.html#_inventory"><i class="fa fa-sitemap"></i></a>
-                        <h4>Inventory</h4>
-                        <p>Keep track of the monitored topology and all the monitored resource metadata. <a href="/overview/index.html#_inventory">More...</a></p>
-                    </li>
-                    <li class="col-md-4 col-sm-4">
-                        <a href="/overview/index.html#_metric_data_visualization"><i class="fa fa-bar-chart"></i></a>
-                        <h4>Metric Data Visualization</h4>
-                        <p>View your data and add charts where you need them most, including real time monitoring. <a href="/overview/index.html#_metric_data_visualization">More...</a></p>
-                    </li>
-                    <li class="col-md-4 col-sm-4">
+                    <li class="col-md-3">
+                        <h3>Distributed Tracing</h3>
                         <a href="/overview/index.html#_application_performance_management"><i class="fa fa-briefcase"></i></a>
-                        <h4>Application Performance Management</h4>
-                        <p>Capture information about the application invocations being executed across your servers. <a href="/hawkular-apm/index.html">More...</a></p>
+                        <p class="text-left">The Hawkular Team collaborate on the Jaeger OpenTracing distributed tracing project.</p>
+                        <p class="text-left"><a href="http://jaeger.readthedocs.io/en/latest/">Documentation</a></p>
+                        <p class="text-left"><a href="https://github.com/uber/jaeger">Github</a></p>
                     </li>
-                    <li class="col-md-4 col-sm-4">
+                    <li class="col-md-3">
+                        <h3>Metrics TSDB</h3>
+                        <a href="/overview/index.html#_metric_storage"><i class="fa fa-bar-chart"></i></a>
+                        <p class="text-left">H-Metrics is a Scalable, performant, long-term TSDB based on Cassandra.</p>
+                        <p class="text-left"><a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>hawkular-metrics/docs/user-guide/">About</a></p>
+                        <p class="text-left"><a href="https://github.com/hawkular/hawkular-metrics/releases/">Download</a></p>
+                        <p class="text-left"><a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>hawkular-metrics/docs/user-guide/">User Guide</a></p>
+                        <p class="text-left"><a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>docs/rest/rest-metrics.html">REST API Guide</a></p>
+                        <p class="text-left"><a href="http://github.com/hawkular/hawkular-metrics">Github</a></p>
+                    </li>
+                    <li class="col-md-3">
+                        <h3>ManageIQ Provider</h3>
                         <a href="http://manageiq.org/"><img src="http://avatars0.githubusercontent.com/ManageIQ?&s=48" alt="ManageIQ logo"></img></a>
-                        <h4>Integration with ManageIQ</h4>
-                        <p>ManageIQ lets you manage container, virtual, private, and public cloud infrastructures. <a href="http://manageiq.org/">More...</a></p>
+                        <p class="text-left">The ManageIQ middleware provider is powered by Hawkular Services.</p>
+                        <p class="text-left"><a href="https://github.com/hawkular/hawkular-services">About</a></p>
+                        <p class="text-left"><a href="http://manageiq.org/">ManageIQ</a></p>
+                        <p class="text-left"><a href="http://github.com/ManageIQ/manageiq-providers-hawkular/">ManageIQ Hawkular Provider</a></p>
+                        <p class="text-left"><a href="http://github.com/hawkular/hawkular-client-ruby/">Hawkular Client - Ruby</a></p>
                     </li>
                 </ul>
             </div>

--- a/src/main/jbake/templates/navigation.ftl
+++ b/src/main/jbake/templates/navigation.ftl
@@ -1,175 +1,59 @@
-    	<!-- Fixed navbar -->
-        <nav class="navbar navbar-fixed-top" role="navigation">
-          <div class="container">
-            <!-- Brand and toggle get grouped for better mobile display -->
-            <div class="navbar-header">
-              <button class="navbar-toggle collapsed" data-target="#bs-example-navbar-collapse-1" data-toggle="collapse" type="button">
-                <span class="sr-only">Toggle navigation</span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-              </button>
-              <a class="navbar-brand" href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>">Home</a>
-            </div>
-            <!-- Collect the nav links, forms, and other content for toggling -->
-            <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
-              <ul class="nav navbar-nav">
-                <li><a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>overview/">Overview</a></li>
-                <li><a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>blog.html">Blog</a></li>
-                <li class="dropdown">
-                  <a aria-expanded="false" class="dropdown-toggle" data-toggle="dropdown" href="#" role="button">
-                    Hawkular Services<span class="caret"></span>
-                  </a>
-                  <ul class="dropdown-menu" role="menu">
-                    <li class="menu-item dropdown dropdown-submenu">
-                      <a href="#" class="dropdown-toggle" data-toggle="dropdown">Documentation</a>
-                      <ul class="dropdown-menu">
-                        <li class="menu-item ">
-                          <a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>hawkular-services/docs/quickstart-guide/">Quickstart</a>
-                        </li>
-                        <li class="menu-item ">
-                          <a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>hawkular-services/docs/installation-guide/">Installation Guide</a>
-                        </li>
-                        <li class="menu-item ">
-                          <a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>hawkular-services/docs/user-guide/">User Guide</a>
-                        </li>
-                        <li class="menu-item dropdown dropdown-submenu">
-                          <a href="#" class="dropdown-toggle" data-toggle="dropdown">REST API</a>
-                          <ul class="dropdown-menu">
-                            <li class="menu-item ">
-                              <a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>docs/rest/rest-alerts.html">Alerting</a>
-                            </li>
-                            <li class="menu-item ">
-                              <a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>docs/rest/rest-inventory.html">Inventory</a>
-                            </li>
-                            <li class="menu-item ">
-                              <a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>docs/rest/rest-metrics.html">Metrics</a>
-                            </li>
-                          </ul>
-                        </li>
-                      </ul>
-                    </li>
-                    <li>
-                      <a href="https://github.com/hawkular/hawkular-services/releases">Download</a>
-                    </li>
-                  </ul>
-                </li>
-                <li class="dropdown">
-                  <a aria-expanded="false" class="dropdown-toggle" data-toggle="dropdown" href="#" role="button">
-                    Hawkular APM<span class="caret"></span>
-                  </a>
-                  <ul class="dropdown-menu" role="menu">
-                    <li>
-                      <li><a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>hawkular-apm/">Overview</a></li>
-                    </li>
-                    <li>
-                      <a href="https://hawkular.gitbooks.io/hawkular-apm-user-guide/content/">Documentation</a>
-                    </li>
-                    <li>
-                      <a href="https://github.com/hawkular/hawkular-apm/releases/">Download</a>
-                    </li>
-                  </ul>
-                </li>
-                <li class="dropdown">
-                  <a aria-expanded="false" class="dropdown-toggle" data-toggle="dropdown" href="#" role="button">
-                    Hawkular Metrics<span class="caret"></span>
-                  </a>
-                  <ul class="dropdown-menu" role="menu">
-                  <li class="menu-item dropdown dropdown-submenu">
-                    <a href="#" class="dropdown-toggle" data-toggle="dropdown">Documentation</a>
-                      <ul class="dropdown-menu">
-                        <li class="menu-item ">
-                          <a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>hawkular-metrics/docs/user-guide/">Metrics User Guide</a>
-                        </li>
-                        <li class="menu-item ">
-                            <a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>community/docs/developer-guide/alerts-v1.html">Alerting User Guide</a>
-                        </li>
-                        <li class="menu-item ">
-                          <a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>docs/rest/rest-metrics.html">Metrics REST API</a>
-                        </li>
-                        <li class="menu-item ">
-                          <a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>docs/rest/rest-alerts-v1.html">Alerting REST API</a>
-                        </li>
-                      </ul>
-                  </li>
-                    <li>
-                      <a href="https://github.com/hawkular/hawkular-metrics/releases/">Download</a>
-                    </li>
-                  </ul>
-                </li>
-                <li class="dropdown">
-                  <a aria-expanded="false" class="dropdown-toggle" data-toggle="dropdown" href="#" role="button">
-                    Hawkular Alerting<span class="caret"></span>
-                  </a>
-                  <ul class="dropdown-menu" role="menu">
-                  <li class="menu-item dropdown dropdown-submenu">
-                    <a href="#" class="dropdown-toggle" data-toggle="dropdown">Documentation</a>
-                      <ul class="dropdown-menu">
-                        <li class="menu-item dropdown dropdown-submenu">
-                            <a href="#" class="dropdown-toggle" data-toggle="dropdown">Alerting User Guide</a>
-                            <ul class="dropdown-menu">
-                              <li class="menu-item ">
-                                <a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>community/docs/developer-guide/alerts-v1.html">Version 1</a>
-                              </li>
-                              <li class="menu-item ">
-                                <a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>community/docs/developer-guide/alerts-v2.html">Version 2</a>
-                              </li>
-                            </ul>
-                        </li>
-                        <li class="menu-item dropdown dropdown-submenu">
-                            <a href="#" class="dropdown-toggle" data-toggle="dropdown">Alerting REST API</a>
-                            <ul class="dropdown-menu">
-                              <li class="menu-item ">
-                                <a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>docs/rest/rest-alerts-v1.html">Version 1</a>
-                              </li>
-                              <li class="menu-item ">
-                                <a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>docs/rest/rest-alerts-v2.html">Version 2</a>
-                              </li>
-                            </ul>
-                        </li>
-                      </ul>
-                  </li>
-                    <li>
-                      <a href="https://github.com/hawkular/hawkular-alerts/releases/">Download</a>
-                    </li>
-                  </ul>
-                </li>
-                <li><a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>hawkular-clients/">Hawkular Clients</a></li>
-                <li class="dropdown"><a aria-expanded="false" class="dropdown-toggle" data-toggle="dropdown" href="#" role="button">
-                  Community
-                  <span class="caret"></span>
-                </a>
-                <ul class="dropdown-menu" role="menu">
-                  <li>
-                    <a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>community/docs/getting-involved/">Getting Involved</a>
+<!-- Fixed navbar -->
+<nav class="navbar navbar-fixed-top" role="navigation">
+  <div class="container">
+    <!-- Brand and toggle get grouped for better mobile display -->
+    <div class="navbar-header">
+      <a class="navbar-brand" href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>/">Home</a>
+    </div>
+    <!-- Collect the nav links, forms, and other content for toggling -->
+    <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
+      <ul class="nav navbar-nav">
+        <li><a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>blog.html" role="button">Blog</a></li>
+        <li class="dropdown"><a aria-expanded="false" class="dropdown-toggle" data-toggle="dropdown" href="#" role="button">
+          Community
+          <span class="caret"></span>
+          </a>
+          <ul class="dropdown-menu" role="menu">
+            <li class="menu-item">
+              <a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>community/docs/getting-involved/">Getting Involved</a>
+            </li>
+            <li class="menu-item">
+              <a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>community/docs/developer-guide/">Developer Guide</a>
+            </li>
+            <li class="menu-item dropdown dropdown-submenu">
+              <a href="#" class="dropdown-toggle" data-toggle="dropdown">Labs</a>
+                <ul class="dropdown-menu">
+                  <li class="menu-item ">
+                    <a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>community/labs/datamining/">Datamining</a>
                   </li>
                   <li class="menu-item ">
-                    <a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>community/docs/developer-guide/">Developer Guide</a>
+                    <a href="https://github.com/pilhuhn/hawkfx">HawkFX</a>
                   </li>
-                  <li class="menu-item dropdown dropdown-submenu">
-                    <a href="#" class="dropdown-toggle" data-toggle="dropdown">Labs</a>
-                      <ul class="dropdown-menu">
-                        <li class="menu-item ">
-                          <a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>community/labs/datamining/">Datamining</a>
-                        </li>
-                        <li class="menu-item ">
-                          <a href="https://github.com/pilhuhn/hawkfx">HawkFX</a>
-                        </li>
-                        <li class="menu-item ">
-                          <a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>hawkular-clients/android-client/">Android client</a>
-                        </li>
-                        <li class="menu-item ">
-                          <a href="https://github.com/jotak/hawkular-java-toolbox">Client-side java toolbox</a>
-                        </li>
-                      </ul>
+                  <li class="menu-item ">
+                    <a href="<#if (content.rootpath)??>${content.rootpath}<#else></#if>hawkular-clients/android-client/">Android client</a>
                   </li>
-                  <li>
-                    <a href="https://github.com/hawkular">GitHub Repositories</a>
-                  <li>
-                    <a href="https://travis-ci.org/hawkular">CI Builds</a>
+                  <li class="menu-item ">
+                    <a href="https://github.com/jotak/hawkular-java-toolbox">Client-side java toolbox</a>
                   </li>
-                </ul></li>
-              </ul>
-            </div>
-          </div>
-        </nav>
+                </ul>
+            </li>
+            <li>
+              <a href="https://github.com/hawkular">GitHub Repositories</a>
+            <li>
+              <a href="https://travis-ci.org/hawkular">CI Builds</a>
+            </li>
+          </ul>
+        </li>
+      </ul>
+      <div id="wrap">
+        <div class="dropup">
+          <a class="tabnav-closed" href="#" id="tab">Red Hat</a>
+          <script>
+            window.addEventListener('load', function() {
+              renderTabzilla("Hawkular", "https://hawkular.github.io", true );
+            }, false);
+          </script>
+        </div>
+      </div>
+    </div>
+</nav>


### PR DESCRIPTION
- promote jaeger, hAlerts, MIQ and hMetrics more prominently
  - provide easier access to relevant links
- clean up nav bar by removing all of the busy menus
- de-emphasize hServices outside of MIQ
- Add some revised text by Julie

Perhaps this is folly as previous attempts have been killed off, but I offer up another proposed revision of the hawkular landing page.  Note that the links for everything other than alerts are just an initial stab, and they can be updated to anything the owners prefer.

This is motivated by wanting to better promote the upcoming Alerting 2.0 release, but also to better promote the other relevant components at this time and clean things up a bit.  Note that there is still a *lot* of outdated content accessible via the site, but I'm hoping this is an interim step towards a better experience for anyone landing on our page.